### PR TITLE
Use Set<String> as index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
           <version>1.1.8.RELEASE</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-library</artifactId>
+          <version>1.3</version>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -142,6 +142,14 @@ public class WebJarAssetLocator {
         this.fullPathIndex = fullPathIndex;
     }
 
+    public WebJarAssetLocator(Set<String> assetPaths) {
+        this.fullPathIndex = new TreeMap<String, String>();
+        
+        for (String assetPath : assetPaths) {
+            fullPathIndex.put(reversePath(assetPath), assetPath);
+        }
+    }
+
     private String throwNotFoundException(final String partialPath) {
         throw new IllegalArgumentException(
                 partialPath
@@ -231,18 +239,22 @@ public class WebJarAssetLocator {
         return fullPathIndex;
     }
 
+    public Set<String> listAssets() {
+        return listAssets("");
+    }
+    
     /**
      * List assets within a folder.
      *
-     * @param folderPath the root path to the folder. Must begin with '/'.
+     * @param folderPath the root path to the folder.
      * @return a set of folder paths that match.
      */
     public Set<String> listAssets(final String folderPath) {
         final Collection<String> allAssets = fullPathIndex.values();
         final Set<String> assets = new HashSet<String>();
-        final String prefix = WEBJARS_PATH_PREFIX + folderPath;
+        final String prefix = WEBJARS_PATH_PREFIX + (!folderPath.startsWith("/") ? "/" : "") + folderPath;
         for (final String asset : allAssets) {
-            if (asset.startsWith(prefix)) {
+            if (asset.startsWith(folderPath) || asset.startsWith(prefix)) {
                 assets.add(asset);
             }
         }

--- a/src/test/java/org/webjars/ManualIndexTest.java
+++ b/src/test/java/org/webjars/ManualIndexTest.java
@@ -1,0 +1,44 @@
+package org.webjars;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashSet;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ManualIndexTest {
+
+    @Test
+    public void should_find_full_path() throws Exception {
+        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css")));
+        
+        assertEquals("META-INF/resources/myapp/app.js", locator.getFullPath("app.js"));
+        assertEquals("META-INF/resources/myapp/app.js", locator.getFullPath("myapp/app.js"));
+        assertEquals("assets/users/login.css", locator.getFullPath("login.css"));
+        assertEquals("assets/users/login.css", locator.getFullPath("users/login.css"));
+    }
+    
+    @Test
+    public void should_list_assets() throws Exception {
+        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
+        
+        assertThat(locator.listAssets("META-INF"), contains("META-INF/resources/webjars/third_party/1.5.2/file.js", "META-INF/resources/myapp/app.js"));
+        assertThat(locator.listAssets("assets"), contains("assets/users/login.css"));
+        assertThat(locator.listAssets("third_party"), contains("META-INF/resources/webjars/third_party/1.5.2/file.js"));
+        assertThat(locator.listAssets(), contains("assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js", "META-INF/resources/myapp/app.js"));
+    }
+    
+    @Test
+    public void should_find_webjars() throws Exception {
+        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
+        
+        Map<String, String> webJars = locator.getWebJars();
+        
+        assertThat(webJars.keySet(), contains("third_party"));
+        assertThat(webJars.values(), contains("1.5.2"));
+    }
+}

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -2,6 +2,7 @@ package org.webjars;
 
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -171,6 +172,11 @@ public class WebJarAssetLocatorTest {
         Map.Entry<String, String> webjar = WebJarAssetLocator.getWebJar("META-INF/resources/webjars/foo/1.0.0/asdf.js");
         assertEquals(webjar.getKey(), "foo");
         assertEquals(webjar.getValue(), "1.0.0");
+    }
+    
+    @Test
+    public void invalid_webjar_path_should_return_null() {
+        assertNull(WebJarAssetLocator.getWebJar("foo/1.0.0/asdf.js"));
     }
 
     @Test


### PR DESCRIPTION
So far, I've added WebJarAssetLocator(Set<String) in backwards-compatible way. I don't think any of the semantics have changed, but it's worth looking over the changes.

There are a few methods that could be pruned and some behaviour that might change, to avoid accumulating cruft. Linked to #67 and #66 .