### PR TITLE
Assets are listed in alphabetical order

### DIFF
--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -37,6 +37,13 @@ public class WebJarAssetLocator {
      */
     public static final String WEBJARS_PATH_PREFIX = "META-INF/resources/webjars";
 
+    private static final Comparator<String> IGNORE_CASE_COMPARATOR = new Comparator<String>() {
+        @Override
+        public int compare(String o1, String o2) {
+            return o1.compareToIgnoreCase(o2);
+        }
+    };
+
     private static Pattern WEBJAR_EXTRACTOR_PATTERN = Pattern.compile(WEBJARS_PATH_PREFIX + "/([^/]*)/([^/]*)/(.*)$");
 
     private static void aggregateFile(final File file, final Set<String> aggregatedChildren, final Pattern filterExpr) {
@@ -263,12 +270,7 @@ public class WebJarAssetLocator {
      */
     public Set<String> listAssets(final String folderPath) {
         final Collection<String> allAssets = fullPathIndex.values();
-        final Set<String> assets = new TreeSet<String>(new Comparator<String>() {
-            @Override
-            public int compare(String o1, String o2) {
-                return o1.compareToIgnoreCase(o2);
-            }
-        });
+        final Set<String> assets = new TreeSet<String>(IGNORE_CASE_COMPARATOR);
         final String prefix = WEBJARS_PATH_PREFIX + (!folderPath.startsWith("/") ? "/" : "") + folderPath;
         for (final String asset : allAssets) {
             if (asset.startsWith(folderPath) || asset.startsWith(prefix)) {

--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -1,14 +1,26 @@
 package org.webjars;
 
-import org.webjars.urlprotocols.UrlProtocolHandler;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.webjars.urlprotocols.UrlProtocolHandler;
 
 /**
  * Locate WebJar assets. The class is thread safe.
@@ -251,7 +263,12 @@ public class WebJarAssetLocator {
      */
     public Set<String> listAssets(final String folderPath) {
         final Collection<String> allAssets = fullPathIndex.values();
-        final Set<String> assets = new HashSet<String>();
+        final Set<String> assets = new TreeSet<String>(new Comparator<String>() {
+            @Override
+            public int compare(String o1, String o2) {
+                return o1.compareToIgnoreCase(o2);
+            }
+        });
         final String prefix = WEBJARS_PATH_PREFIX + (!folderPath.startsWith("/") ? "/" : "") + folderPath;
         for (final String asset : allAssets) {
             if (asset.startsWith(folderPath) || asset.startsWith(prefix)) {

--- a/src/test/java/org/webjars/ManualIndexTest.java
+++ b/src/test/java/org/webjars/ManualIndexTest.java
@@ -26,10 +26,10 @@ public class ManualIndexTest {
     public void should_list_assets() throws Exception {
         WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
         
-        assertThat(locator.listAssets("META-INF"), contains("META-INF/resources/webjars/third_party/1.5.2/file.js", "META-INF/resources/myapp/app.js"));
+        assertThat(locator.listAssets("META-INF"), contains("META-INF/resources/myapp/app.js", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
         assertThat(locator.listAssets("assets"), contains("assets/users/login.css"));
         assertThat(locator.listAssets("third_party"), contains("META-INF/resources/webjars/third_party/1.5.2/file.js"));
-        assertThat(locator.listAssets(), contains("assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js", "META-INF/resources/myapp/app.js"));
+        assertThat(locator.listAssets(), contains("assets/users/login.css", "META-INF/resources/myapp/app.js", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
     }
     
     @Test


### PR DESCRIPTION
Fixes problem raised in #68, which was perhaps due to different HashSet ordering implementations on Linux and Mac?