### PR TITLE
getFullPath(String) now works when the entire path is given.

### DIFF
--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -133,11 +133,10 @@ public class WebJarAssetLocator {
         final String[] assetPathComponents = assetPath.split("/");
         final StringBuilder reversedAssetPath = new StringBuilder();
         for (int i = assetPathComponents.length - 1; i >= 0; --i) {
-            if (reversedAssetPath.length() > 0) {
-                reversedAssetPath.append('/');
-            }
             reversedAssetPath.append(assetPathComponents[i]);
+            reversedAssetPath.append('/');
         }
+        
         return reversedAssetPath.toString();
     }
 
@@ -200,7 +199,11 @@ public class WebJarAssetLocator {
     }
 
     private String getFullPath(SortedMap<String, String> pathIndex, String partialPath) {
-        final String reversePartialPath = reversePath(prependSlash(partialPath));
+        if (partialPath.charAt(0) == '/') {
+            partialPath = partialPath.substring(1);
+        }
+        
+        final String reversePartialPath = reversePath(partialPath);
 
         final SortedMap<String, String> fullPathTail = pathIndex.tailMap(reversePartialPath);
 
@@ -238,20 +241,6 @@ public class WebJarAssetLocator {
             }
         }
         return filteredPathIndex;
-    }
-
-    /**
-     * Prepends a forward slash to a path if there isn't already a forward slash at the front of the path
-     *
-     * @param path the old path
-     * @return the new path
-     */
-    private String prependSlash(final String path) {
-        if (path.startsWith("/")) {
-            return path;
-        } else {
-            return "/" + path;
-        }
     }
 
     public SortedMap<String, String> getFullPathIndex() {

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -190,4 +190,10 @@ public class WebJarAssetLocatorTest {
         assertEquals(webjars.get("angularjs"), "1.2.11");
     }
 
+    @Test
+    public void should_match_when_full_path_given() throws Exception {
+        WebJarAssetLocator locator = new WebJarAssetLocator();
+        
+        assertEquals("META-INF/resources/webjars/bootstrap/3.1.1/less/.csscomb.json", locator.getFullPath("META-INF/resources/webjars/bootstrap/3.1.1/less/.csscomb.json"));
+    }
 }


### PR DESCRIPTION
Previously, "META-INF/resources/webjars/my_webjar/1.0.0/asset.js" threw a not found exception. This was generally OK because the META-INF wasn't meant to be specified.

However, for manually-specified webjars outside META-INF/resources/webjars, providing the entire path can happen in dynamic lookup situations.