### PR TITLE
babel-runtime fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
             <groupId>org.webjars.npm</groupId>
             <artifactId>validate.js</artifactId>
             <version>0.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.npm</groupId>
+            <artifactId>babel-runtime</artifactId>
+            <version>5.8.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/webjars/RequireJS.java
+++ b/src/main/java/org/webjars/RequireJS.java
@@ -425,10 +425,6 @@ public final class RequireJS {
 
                 return requireConfig;
 
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
-                log.warn("Could not create the RequireJS config for the " + webJar.getKey() + " " + webJar.getValue() + " WebJar" + " from " + path + "\n" +
-                        "Please file a bug at: http://github.com/webjars/webjars-locator/issues/new");
             } catch (IOException e) {
                 e.printStackTrace();
                 log.warn("Could not create the RequireJS config for the " + webJar.getKey() + " " + webJar.getValue() + " WebJar" + " from " + path + "\n" +
@@ -557,11 +553,7 @@ public final class RequireJS {
                     }
                 }
 
-            } catch (ParserConfigurationException e) {
-                log.warn(requireJsConfigErrorMessage(webJar));
-            } catch (IOException e) {
-                log.warn(requireJsConfigErrorMessage(webJar));
-            } catch (SAXException e) {
+            } catch (ParserConfigurationException | IOException | SAXException e) {
                 log.warn(requireJsConfigErrorMessage(webJar));
             } finally {
                 try {

--- a/src/main/java/org/webjars/RequireJS.java
+++ b/src/main/java/org/webjars/RequireJS.java
@@ -408,13 +408,17 @@ public final class RequireJS {
                 String name = jsonNode.get("name").asText();
                 String requireFriendlyName = name.replaceAll("\\.", "-");
 
-                if (jsonNode.get("main").getNodeType() == JsonNodeType.STRING) {
-                    String main = jsonNode.get("main").asText();
+                JsonNode mainJs = jsonNode.get("main");
+                if (mainJs == null)
+                    throw new IllegalArgumentException("no 'main' attribute; cannot generate a config");
+
+                if (mainJs.getNodeType() == JsonNodeType.STRING) {
+                    String main = mainJs.asText();
                     requireConfigPaths.put(requireFriendlyName, mainJsToPathJson(webJar, main, prefixes));
                 }
-                else if (jsonNode.get("main").getNodeType() == JsonNodeType.ARRAY) {
+                else if (mainJs.getNodeType() == JsonNodeType.ARRAY) {
                     ArrayList<String> mainList = new ArrayList<>();
-                    for (JsonNode mainJsonNode : jsonNode.withArray("main")) {
+                    for (JsonNode mainJsonNode : mainJs) {
                         mainList.add(mainJsonNode.asText());
                     }
                     String main = getBowerBestMatchFromMainArray(mainList, name);
@@ -429,6 +433,12 @@ public final class RequireJS {
                 e.printStackTrace();
                 log.warn("Could not create the RequireJS config for the " + webJar.getKey() + " " + webJar.getValue() + " WebJar" + " from " + path + "\n" +
                         "Please file a bug at: http://github.com/webjars/webjars-locator/issues/new");
+            } catch (IllegalArgumentException e) {
+                e.printStackTrace();
+                log.warn("Could not create the RequireJS config for the " + webJar.getKey() + " " + webJar.getValue() + " WebJar" + " from " + path + "\n" +
+                        "There was not enough information in the package metadata to do so.\n" +
+                        "If you think you have received this message in error, " +
+                        "please file a bug at: http://github.com/webjars/webjars-locator/issues/new");
             } finally {
                 try {
                     inputStream.close();

--- a/src/test/java/org/webjars/RequireJSTest.java
+++ b/src/test/java/org/webjars/RequireJSTest.java
@@ -101,4 +101,10 @@ public class RequireJSTest {
         assertEquals(WEBJAR_URL_PREFIX + "validate.js/0.8.0/validate", jsonNoCdn.get("validate.js").get("paths").get("validate-js").get(0).asText());
     }
 
+    @Test
+    public void should_be_empty_if_no_main() {
+        Map<String, ObjectNode> json = RequireJS.getSetupJson(WEBJAR_URL_PREFIX);
+        assertNull(json.get("babel-runtime"));
+    }
+
 }

--- a/src/test/java/org/webjars/RequireJSTest.java
+++ b/src/test/java/org/webjars/RequireJSTest.java
@@ -62,7 +62,7 @@ public class RequireJSTest {
         // todo: the angular version changes due to a range transitive dependency
 
         assertEquals(WEBJAR_URL_PREFIX + "angular-bootstrap/0.13.0/ui-bootstrap-tpls", jsonNoCdn.get("angular-bootstrap").get("paths").get("angular-bootstrap").get(0).asText());
-        assertEquals(WEBJAR_URL_PREFIX + "angular/1.4.3/angular", jsonNoCdn.get("angular").get("paths").get("angular").get(0).asText());
+        assertEquals(WEBJAR_URL_PREFIX + "angular/1.4.4/angular", jsonNoCdn.get("angular").get("paths").get("angular").get(0).asText());
 
         Map<String, ObjectNode> jsonWithCdn = RequireJS.getSetupJson(WEBJAR_CDN_PREFIX, WEBJAR_URL_PREFIX);
 


### PR DESCRIPTION
The two first commits are take-it-or-leave-it - one is a fix that I'm not sure is good across all systems ("RequireJSTest: Bump angular version") and another is a style change that ended up being irrelevant to what I did ("Clean up exception handling").

fixes #88 