### PR TITLE
tolerate null return from ObjectMapper.readTree("")

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
+            <artifactId>bootswatch</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
             <artifactId>when-node</artifactId>
             <version>3.5.2-2</version>
             <scope>test</scope>

--- a/src/main/java/org/webjars/RequireJS.java
+++ b/src/main/java/org/webjars/RequireJS.java
@@ -267,7 +267,7 @@ public final class RequireJS {
 
         try {
             JsonNode maybeRequireJsConfig = mapper.readTree(rawRequireJsConfig);
-            if (maybeRequireJsConfig.isObject()) {
+            if (maybeRequireJsConfig != null && maybeRequireJsConfig.isObject()) {
                 // The provided config was parseable, now lets fix the paths
 
                 webJarRequireJsNode = (ObjectNode) maybeRequireJsConfig;
@@ -347,7 +347,11 @@ public final class RequireJS {
                 }
 
             } else {
-                log.error(requireJsConfigErrorMessage(webJar));
+                if (rawRequireJsConfig.length() > 0) {
+                    log.error(requireJsConfigErrorMessage(webJar));
+                } else {
+                    log.warn(requireJsConfigErrorMessage(webJar));
+                }
             }
         } catch (IOException e) {
             log.warn(requireJsConfigErrorMessage(webJar));

--- a/src/test/java/org/webjars/RequireJSTest.java
+++ b/src/test/java/org/webjars/RequireJSTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -111,6 +112,12 @@ public class RequireJSTest {
     public void should_be_ok_with_index_file_but_no_main() {
         Map<String, ObjectNode> json = RequireJS.getSetupJson(WEBJAR_URL_PREFIX);
         assertEquals(WEBJAR_URL_PREFIX + "object-assign/4.1.0/index", json.get("object-assign").get("paths").get("object-assign").get(0).asText());
+    }
+
+    @Test
+    public void should_load_webjar_without_requirejs_properties() {
+        ObjectNode objectNode = RequireJS.getWebJarRequireJsConfig(new AbstractMap.SimpleEntry<>("bootswatch", "2.3.1"), Collections.<Map.Entry<String, Boolean>>emptyList());
+        assertEquals(0, objectNode.size());
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/webjars/webjars-locator/issues/108