### PR TITLE
Downgrade jackson to 2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.14.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Akka, Pekko, Play etc. all stay on 2.14 for now. To avoid conflicts it would be nice if we do so as well. (Conflicts are likely with https://github.com/FasterXML/jackson-module-scala because it complains and fails hard if versions don't match.)