### PR TITLE
Dependabot should ignore future jackson updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "jackson-databind"
+        versions: ["2.x"]
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
I think this should work, I think the dependency is called `jackson-databind` according to
- #45