### PR TITLE
Revert "Dependabot should ignore future jackson updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "jackson-databind"
-        versions: ["2.x"]
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This reverts commit 87613a1726cdf0e046b51fe372596a39ad80f7e3.

1. It was not working anyway didn't prevent this PR: #98
2. It is no needed anymore because I figured out it should be OK to upgrade to latest jackson release anyway.